### PR TITLE
Store Objects Purchase fix

### DIFF
--- a/client/functions/requestStoreObject.sqf
+++ b/client/functions/requestStoreObject.sqf
@@ -8,7 +8,7 @@
 
 [[player, _class, currentOwnerName, _requestKey], "spawnStoreObject", false, false] call TPG_fnc_MP;
 
-private "_requestTime";
+private ["_requestTime", "_object"];
 _requestTime = time;
 hint "Awaiting server response...";
 
@@ -18,21 +18,44 @@ hint "Awaiting server response...";
 	storePurchaseHandle = nil; // To allow purchasing more stuff in the meanwhile
 };
 
-waitUntil {!isNil _requestKey || {time >= _requestTime + 15}}; // 15s timeout
+waitUntil 
+{
+    sleep 0.5;
+    if (time >= _requestTime + 15) exitWith {true}; // 15s timeout
+    _object = player getVariable _requestKey;
+    if (!isNil "_object") exitWith {true};
+    false
+};
 
-if (isNil _requestKey || {isNull objectFromNetId (missionNamespace getVariable _requestKey)}) then
+if (isNil "_object") then
+{
+    hint "_object is nil";
+};
+sleep 5;
+
+
+
+if (isNil "_object" || {isNull objectFromNetId (_object)}) then
 {
 	_requestKey spawn // If the object somehow spawns after the timeout, delete it
 	{
 		private ["_requestKey", "_postTimeout", "_object"];
 		_requestKey = _this;
 		_postTimeout = time;
-		waitUntil {!isNil _requestKey || {time >= _postTimeout + 60}}; // 60s post-timeout
+        
+        waitUntil 
+        {
+            sleep 0.5;
+            if (time >= _postTimeout + 60) exitWith {true}; // 15s timeout
+            _object = player getVariable _requestKey;
+            if (!isNil "_object") exitWith {true};
+            false
+        };
 		
-		if (!isNil _requestKey) then
+		if (!isNil _object) then
 		{
-			deleteVehicle objectFromNetId (missionNamespace getVariable _requestKey);
-			missionNamespace setVariable [_requestKey, nil];
+			deleteVehicle objectFromNetId (_object);
+            _player setVariable [_requestKey, nil, true];
 		};
 	};
 	
@@ -41,4 +64,5 @@ if (isNil _requestKey || {isNull objectFromNetId (missionNamespace getVariable _
 else
 {
 	[_itemText] call _showItemSpawnedOutsideMessage;
+    player setVariable [_requestKey, nil, true];
 };

--- a/server/functions/spawnStoreObject.sqf
+++ b/server/functions/spawnStoreObject.sqf
@@ -68,6 +68,6 @@ if (_key != "" && {isPlayer _player} && {_isGeneralStore || _isGunStore} && {{_x
 			};
 		};
 	};
-	
-	[compile format ["%1 = '%2'", _key, _objectID], "BIS_fnc_spawn", _player, false] call TPG_fnc_MP;
+	// [compile format ["%1 = '%2'", _key, _objectID], "BIS_fnc_spawn", _player, false] call TPG_fnc_MP;
+    _player setVariable [_key, _objectID, true];
 };


### PR DESCRIPTION
Sometimes Object purchase from the Stores fails because 

[compile format ["%1 = '%2'", _key, _objectID], "BIS_fnc_spawn", _player, false] call TPG_fnc_MP;

doesn't seem to create the variable on the client. The purchase says that it doesn't go through because of an error and no money is deducted, but the object is still spawned outside the store and the client cannot delete it because it doesn't know the object ID.
