### PR TITLE
Use Blue Water Barrels

### DIFF
--- a/addons/R3F_ARTY_AND_LOG/R3F_LOG/config.sqf
+++ b/addons/R3F_ARTY_AND_LOG/R3F_LOG/config.sqf
@@ -151,7 +151,7 @@ R3F_LOG_CFG_objets_transportables =
 	["Land_Shoot_House_Wall_F", 3],
 	["Land_Stone_8m_F", 5],
 	["Land_ToiletBox_F", 2],
-	["Land_WaterBarrel_F", 2]
+	["Land_BarrelWater_F", 2]
 ];
 
 /****** MOVABLE-BY-PLAYER OBJECTS / OBJETS DEPLACABLES PAR LE JOUEUR ******/
@@ -207,5 +207,5 @@ R3F_LOG_CFG_objets_deplacables =
 	"Land_Shoot_House_Wall_F",
 	"Land_Stone_8m_F",
 	"Land_ToiletBox_F",
-	"Land_WaterBarrel_F"
+	"Land_BarrelWater_F"
 ];

--- a/client/items/survival/init.sqf
+++ b/client/items/survival/init.sqf
@@ -54,7 +54,7 @@ MF_ITEMS_ENERGY_DRINK = "energydrink";
     private["_label", "_code", "_condition"];
     _label = "<img image='client\icons\water.paa'/> Fill water container";
     _code = {
-        _nobj = (nearestobjects [player, ["Land_WaterBarrel_F"],  5] select 0);
+        _nobj = (nearestobjects [player, ["Land_BarrelWater_F"],  5] select 0);
         _nobj setVariable["water",(_nobj getVariable "water")-1,true];
         [MF_ITEMS_WATER, 1] call mf_inventory_add;
         player playmove "AinvPknlMstpSlayWrflDnon";
@@ -64,16 +64,16 @@ MF_ITEMS_ENERGY_DRINK = "energydrink";
                 _vecu = vectorUp _this;
                 _vecd = vectorDir _this;
                 deleteVehicle _this;
-                _veh = createVehicle ["Land_Barrel_empty", _npos, [], 0, "CAN_COLLIDE"];
+                _veh = createVehicle ["Land_BarrelEmpty_F", _npos, [], 0, "CAN_COLLIDE"];
                 _veh setVectorDirAndUp [_vecd, _vecu];
-                _veh spawn {sleep 5; deleteVehicle _this};
+                _veh spawn {sleep 30; deleteVehicle _this};
             };
             hint "You have filled a water container.\nBarrel is empty";
         } else {
             hint format["You have filled a water container.\n(Water left: %1)", (_nobj getVariable "water")];
         };
     };
-    _condition = 'player distance (nearestobjects [player, ["Land_WaterBarrel_F"],  5] select 0) < 5 and not(MF_ITEMS_WATER call mf_inventory_is_full) and (nearestobjects [player, ["Land_WaterBarrel_F"],  5] select 0) getVariable "water" > 0';
+    _condition = 'player distance (nearestobjects [player, ["Land_BarrelWater_F"],  5] select 0) < 5 and not(MF_ITEMS_WATER call mf_inventory_is_full) and (nearestobjects [player, ["Land_BarrelWater_F"],  5] select 0) getVariable "water" > 0';
 	["take-water-barrel", [_label, _code, nil,0, false, false, "", _condition]] call mf_player_actions_set;
 };
 

--- a/persistence/world/oLoad.sqf
+++ b/persistence/world/oLoad.sqf
@@ -30,7 +30,7 @@ for "_i" from 0 to (_objectscount - 1) do
 			_obj setVariable["food",_supplyleft,true];
 		};
 
-		if (_class == "Land_WaterBarrel_F") then 
+		if (_class == "Land_BarrelWater_F") then 
 		{
 			_obj setVariable["water",_supplyleft,true];
 		};

--- a/persistence/world/oSave.sqf
+++ b/persistence/world/oSave.sqf
@@ -44,7 +44,7 @@ while {true} do
 					{
 						_supplyleft = _object getVariable ["food", 20];
 					};
-					case (_object isKindOf "Land_WaterBarrel_F"):
+					case (_object isKindOf "Land_BarrelWater_F"):
 					{ 
 						_supplyleft = _object getVariable ["water", 20];
 					};

--- a/server/functions/serverVars.sqf
+++ b/server/functions/serverVars.sqf
@@ -137,7 +137,7 @@ objectList =
 	"Land_RampConcreteHigh_F",
 	"Land_Sacks_goods_F",
 	"Land_Shoot_House_Wall_F",
-	"Land_WaterBarrel_F"
+	"Land_BarrelWater_F"
 ];
 
 //Object List - Random Spawns.

--- a/server/spawning/objectCreation.sqf
+++ b/server/spawning/objectCreation.sqf
@@ -15,7 +15,7 @@ _obj allowDamage false;
 
 switch (_Objtype) do
 {
-	case "Land_WaterBarrel_F":
+	case "Land_BarrelWater_F":
 	{
 		_obj setVariable["water",50,true];
 	};


### PR DESCRIPTION
I think that the Blue (5 gal?) barrels were supposed to be used for water, so that they could be changed to the empty Blue barrel when they were emptied in survival\init, rather than the large Black (100 gal?) ones?
