### PR TITLE
Allow only independents of same group to enter a vehicle

### DIFF
--- a/client/clientEvents/getInVehicle.sqf
+++ b/client/clientEvents/getInVehicle.sqf
@@ -18,7 +18,7 @@ if (isNil {_veh getVariable "A3W_unconsciousEngineEH"}) then
 	{
 		_veh = _this select 0;
 		_turnedOn = _this select 1;
-		
+
 		if (local _veh && {_turnedOn && (driver _veh) getVariable ["FAR_isUnconscious", 0] == 1}) then
 		{
 			(driver _veh) action ["EngineOff", _veh];
@@ -47,6 +47,7 @@ if ( (count _crew) > 1) then  //player already in vehicle when this code runs - 
 			if (!(playerSide in [BLUFOR,OPFOR]) && group _x != group player ) then //check if other ppl which where in vehicle before are in the players group
 			{
 				player action ["Eject", vehicle player];
+				["You can't enter vehicles of other independent players without grouping first.", 5] call mf_notify_client;
 			}
 		};
 	} forEach _crew;


### PR DESCRIPTION
As independent groups are their own faction in A3W it is not good consequent that other indi's can easily hijack their vehicles.
Although it can be fun to hijack an enemy indi tank (yes, I'm guilty) it think it would be fitting that vehicle restrictions are enforced on a group level for indis.
