### PR TITLE
Extra gravity when jumping

### DIFF
--- a/addons/JumpMF/detect_key_input.sqf
+++ b/addons/JumpMF/detect_key_input.sqf
@@ -33,14 +33,21 @@ if (_pressedKey in actionKeys "GetOver") then
 
 				[player, "AovrPercMrunSrasWrflDf"] call switchMoveGlobal;
 
+
 				waitUntil
 				{
 					player setFatigue (_fatigue + 0.05 + (_load / 5000));
+					private["_zComponent"];
+					_zComponent = (velocity player) select 2;
+					if (((getPosATL player) select 2) > 0 && _zComponent > 0) then {
+					  _zComponent = _zComponent * 0.5;
+					};
+
 					player setVelocity
 					[
 						(_prevVel select 0) * HORDE_JUMPMF_SLOWING_MULTIPLIER,
 						(_prevVel select 1) * HORDE_JUMPMF_SLOWING_MULTIPLIER,
-						(velocity player) select 2
+						_zComponent
 					];
 					!(["AovrPercMrun", animationState player] call fn_startsWith)
 				};


### PR DESCRIPTION
Reduce the Z velocity component by half every waitUntil iteration. This is not entirely physically accurate, as it's not applying really applying 9.8 m/s^2 of deceleration ... but works well to prevent the player from jumping spider-man style.
