### PR TITLE
Fix issue with team-kill kick

### DIFF
--- a/client/functions/playerSpawn.sqf
+++ b/client/functions/playerSpawn.sqf
@@ -10,7 +10,7 @@
 playerSpawning = true;
 
 //Teamkiller Kick
-if (!isNil "pvar_teamKillList") then
+if (!isNil "pvar_teamKillList" && {playerSide in [BLUFOR,OPFOR]}) then
 {
 	if ([pvar_teamKillList, getPlayerUID player, 0] call fn_getFromPairs >= 2) exitWith
 	{


### PR DESCRIPTION
According to the message, you are supposed to be restricted to the
independents team. However, it's not even letting the player join
that team. This fix makes it so that player is only kicked back into the
lobby if he tries to join bluefor or opfor.
