### PR TITLE
Update deleteObjects.sqf

### DIFF
--- a/persistence/server/world/extDB/deleteObjects.sqf
+++ b/persistence/server/world/extDB/deleteObjects.sqf
@@ -10,8 +10,17 @@ _objects = _this;
 _values = "";
 
 {
-	_id = if (typeName _x == "OBJECT") then { _x getVariable "A3W_objectID" } else { _x };
-	_x setVariable ["A3W_objectID", nil];
+	_id = 0;
+	if (typeName _x == "OBJECT") then
+	{
+		_id = _x getVariable "A3W_objectID";
+		_x setVariable ["A3W_objectID", nil];
+	}
+	else
+	{
+		_id = _x;
+	};
+	
 	if (!isNil "_id") then
 	{
 		_values = _values + ((if (_values != "") then { "," } else { "" }) + str _id);

--- a/persistence/server/world/extDB/deleteObjects.sqf
+++ b/persistence/server/world/extDB/deleteObjects.sqf
@@ -11,7 +11,7 @@ _values = "";
 
 {
 	_id = if (typeName _x == "OBJECT") then { _x getVariable "A3W_objectID" } else { _x };
-
+	_x setVariable ["A3W_objectID", nil];
 	if (!isNil "_id") then
 	{
 		_values = _values + ((if (_values != "") then { "," } else { "" }) + str _id);


### PR DESCRIPTION
Should fix a possible scenario where object isn't re-added to Database.

Object is locked + saved to Database

Object is unlocked during object saving and is removed from Database
The very same object is then locked (without been moved).
SQL query updateServerObject is ran
It won't throw any errors when no database entry is found