### PR TITLE
Add Dynamic Zeus Curators to A3W

### DIFF
--- a/addons/aj/aj_FunctionsDefinition.hpp
+++ b/addons/aj/aj_FunctionsDefinition.hpp
@@ -1,0 +1,8 @@
+// @file Name: aj_FunctionsDefinition.hpp
+// @file Author:  wiking.at
+// @file Author: www.armajunkies.de
+
+class ajzeus {
+	file="addons\aj\zeus";
+	class aj_s_initZeus {preInit=1;};	
+};

--- a/addons/aj/zeus/fn_aj_s_initZeus.sqf
+++ b/addons/aj/zeus/fn_aj_s_initZeus.sqf
@@ -1,0 +1,66 @@
+scriptName "fn_aj_s_initZeus";
+// @file Name: fn_aj_s_initZeus.sqf
+// @file Author:  wiking.at
+// @file Author: www.armajunkies.de
+
+if (isServer) then 
+	{
+
+	//load Zeus now - no variables available at pre-init - so do it from scratch
+	if (loadFile ("\A3Wasteland_settings\zeus.sqf") != "") then
+		{
+		diag_log "A3W:Zeus Config File found";
+		call compile preprocessFileLineNumbers ("\A3Wasteland_settings\zeus.sqf");
+		}
+	else
+		{
+		/*******************************************************
+		Player UID examples :
+
+		"1234567887654321", // Meatwad
+		"8765432112345678", // Master Shake
+		"1234876543211234", // Frylock
+		"1337133713371337"  // Carl
+
+		Important: The player UID must always be placed between
+					double quotes (") and all lines need to have
+					a comma (,) except the last one.
+		********************************************************/
+
+
+		// Zeus Admins
+		zeusAdmins = 
+		[
+		// Put player UIDs here
+		];
+		diag_log "A3W:Zeus - no external Zeus Config File found";
+		};
+
+	if (typeName zeusAdmins == "ARRAY") then
+		{ 
+		zeusAdmins = compileFinal str zeusAdmins 
+		};
+
+	publicVariable "zeusAdmins";
+	
+	_zeusAdminList =  call zeusAdmins;
+	
+	    // Create Zeus Module if zeusAdmins are defined
+	if (count _zeusAdminList > 0 && isNil "aj_var_centerSideLogic_Zeus") then
+		{
+		aj_var_centerSideLogic_Zeus = createCenter sideLogic; publicVariable "aj_var_centerSideLogic_Zeus";  //Create game side for Zeus
+		aj_var_groupSideLogic_Zeus = createGroup aj_var_centerSideLogic_Zeus; publicVariable "aj_var_groupSideLogic_Zeus";  //Create group for Zeus
+			
+			//now create the curators for all zeusAdmins
+		   {       
+		   Call Compile Format ["aj_var_modulezeus%1 = aj_var_groupSideLogic_Zeus createUnit ['ModuleCurator_F',[0,0,0] , [], 0, ''];",_x];
+		   Call Compile Format ["aj_var_moduleZeus%1 setVariable ['showNotification', false, true];",_x];
+		   Call Compile Format ["aj_var_moduleZeus%1 setVariable ['birdType', '', true];",_x];
+		   Call Compile Format ["aj_var_moduleZeus%1 setVariable ['Owner', '%1', true];",_x];
+		   Call Compile Format ["aj_var_moduleZeus%1 setVariable ['Addons', 3, true];",_x];
+		   Call Compile Format ["aj_var_moduleZeus%1 setVariable ['Forced', 0, true];",_x];
+		   Call Compile Format ["publicVariable 'aj_var_moduleZeus%1'; ",_x];
+		   }
+		   forEach _zeusAdminList;
+		};	
+};

--- a/addons/aj/zeus/fn_aj_s_refreshZeus.sqf
+++ b/addons/aj/zeus/fn_aj_s_refreshZeus.sqf
@@ -1,0 +1,19 @@
+scriptName "fn_aj_s_refreshZeus";
+// @file Name: fn_aj_s_refreshZeus.sqf
+// @file Author:  wiking.at
+// @file Author: www.armajunkies.de
+
+if (isServer) then {
+    // Refresh map objects if zeus ui is opened
+	
+	private "_zeusUID";
+	_zeusUID = _this;	
+	_zeusUID = missionnamespace  getvariable[_zeusUID,0];
+	
+		{
+		_zeusUID addCuratorEditableObjects [[_x],true];
+		} 
+		foreach (allMissionObjects "All");
+
+	
+};

--- a/addons/aj/zeus/refreshzeus.sqf
+++ b/addons/aj/zeus/refreshzeus.sqf
@@ -1,0 +1,13 @@
+// @file Name: refreshZeus.sqf
+// @file Author:  wiking.at
+// @file Author: www.armajunkies.de
+// Refresh of all Mission Objects and set Owner on Zeus Keypress
+
+
+_uid = getPlayerUID player;
+
+if(_uid in (call zeusAdmins)) then
+	{
+	_zeusUID =  Format ["aj_var_moduleZeus%1",_uid];
+	[_zeusUID, "A3W_fnc_aj_s_refreshZeus", true] call A3W_fnc_MP;  //trigger zeus refresh on server
+	};

--- a/client/CfgRemoteExec_fnc.hpp
+++ b/client/CfgRemoteExec_fnc.hpp
@@ -47,3 +47,4 @@ class A3W_fnc_unflip {};
 // Other third-party
 class APOC_srv_startAirdrop { allowedTargets = 2; };
 class JTS_FNC_SENT {};
+class A3W_fnc_aj_s_refreshZeus {};

--- a/client/clientEvents/customKeys.sqf
+++ b/client/clientEvents/customKeys.sqf
@@ -23,5 +23,6 @@ forEach
 	["A3W_customKeys_adminMenu", [22]], // 22 = U
 	["A3W_customKeys_playerMenu", [41]], // 41 = Tilde (above Tab)
 	["A3W_customKeys_playerNames", [199,219,220]], // 199 = Home, 219 = LWin, 220 = RWin
-	["A3W_customKeys_earPlugs", [207]] // 207 = End
+	["A3W_customKeys_earPlugs", [207]], // 207 = End
+	["A3W_customKeys_AJZeus", [21]] // 21 = Zeus
 ];

--- a/client/clientEvents/onKeyPress.sqf
+++ b/client/clientEvents/onKeyPress.sqf
@@ -53,6 +53,11 @@ switch (true) do
 			["You've taken out your earplugs.", 5] call mf_notify_client;
 		};
 	};
+	// Z Key
+	case (_key in A3W_customKeys_AJZeus):
+	{
+		execVM "addons\aj\zeus\refreshzeus.sqf";
+	};
 };
 
 // ********** Action keys **********

--- a/description.ext
+++ b/description.ext
@@ -80,6 +80,10 @@ class CfgFunctions
 		#include "client\CfgFunctions.hpp"
 		#include "server\CfgFunctions.hpp"
 	};
+	class armajunkies
+	{
+		#include "addons\aj\aj_FunctionsDefinition.hpp"
+	};
 };
 
 class CfgNotifications

--- a/globalCompile.sqf
+++ b/globalCompile.sqf
@@ -126,6 +126,7 @@ vehicleDammagedEvent = [_serverFunc, "vehicleDammagedEvent.sqf"] call mf_compile
 vehicleEngineEvent = [_serverFunc, "vehicleEngineEvent.sqf"] call mf_compile;
 vehicleHandleDamage = [_serverFunc, "vehicleHandleDamage.sqf"] call mf_compile;
 vehicleHitTracking = [_serverFunc, "vehicleHitTracking.sqf"] call mf_compile;
+A3W_fnc_aj_s_refreshZeus = "addons\aj\zeus\fn_aj_s_refreshZeus.sqf" call mf_compile;  //name has has to started with A3W_fnc_ 
 
 call compile preprocessFileLineNumbers "server\functions\mf_remote.sqf";
 

--- a/server/antihack/filterExecAttempt.sqf
+++ b/server/antihack/filterExecAttempt.sqf
@@ -56,6 +56,31 @@ if (_packetName == "BIS_fnc_MP_packet") then
 
 			// NOTE: You also need to whitelist individual functions in client\CfgRemoteExec_fnc.hpp
 		];
+		
+		
+	//allow zeus functions	
+	if (!_whitelisted) then
+	{
+		scopeName "zeusFunc";
+		private ["_zeusFuncCfg", "_zeusFuncPrefix", "_i", "_catCfg", "_j"];
+
+		_zeusFuncCfg = configfile >> "CfgFunctions" >> "A3_Functions_F_Curator";
+		_zeusFuncPrefix = getText (_zeusFuncCfg >> "tag") + "_fnc_";
+
+		for "_i" from 0 to (count _zeusFuncCfg - 1) do
+		{
+			_catCfg = _zeusFuncCfg select _i;
+			for "_j" from 0 to (count _catCfg - 1) do
+			{
+				if (_function == _zeusFuncPrefix + configName (_catCfg select _j)) then
+				{
+					_whitelisted = true;
+					breakOut "zeusFunc";
+				};
+			};
+		};
+	};
+		
 
 		if (!_whitelisted) then
 		{

--- a/server/antihack/payload.sqf
+++ b/server/antihack/payload.sqf
@@ -106,10 +106,11 @@ if (isNil "_cheatFlag") then
 
 			_isAdmin = serverCommandAvailable "#kick";
 
+
 			if (!isNull (findDisplay 49 displayCtrl 0)) exitWith { _cheatFlag = "RscDisplayInterruptEditorPreview" };
 			if (!isNull findDisplay 17 && !isServer && !_isAdmin) exitWith { _cheatFlag = "RscDisplayRemoteMissions (Wookie)" };
 			if (!isNull findDisplay 316000 && !_isAdmin) exitWith { _cheatFlag = "Debug console" }; // RscDisplayDebugPublic
-			if (!isNull (uiNamespace getVariable ["RscDisplayArsenal", displayNull]) && !_isAdmin) exitWith { _cheatFlag = "Virtual Arsenal" };
+			if (!isNull (uiNamespace getVariable ["RscDisplayArsenal", displayNull]) && !_isAdmin && (count (call zeusAdmins) == 0)) exitWith { _cheatFlag = "Virtual Arsenal" }; // AJ - Disabled Arsenal Check if zeusAdmins are defined
 			if (!isNull findDisplay 157 && isNull (uiNamespace getVariable ["RscDisplayModLauncher", displayNull])) exitWith { _cheatFlag = "RscDisplayPhysX3Debug" };
 
 			_display = findDisplay 54;

--- a/server/antihack/serverSide.sqf
+++ b/server/antihack/serverSide.sqf
@@ -11,7 +11,7 @@ if (!isServer) exitWith {};
 waitUntil {!isNil "A3W_serverSetupComplete"};
 if !(["A3W_antiHackUnitCheck"] call isConfigOn) exitWith {};
 
-private ["_flagChecksum", "_serverID", "_cheatFlag", "_unit"];
+private ["_flagChecksum", "_serverID", "_cheatFlag", "_unit","_belongstoZeusAdmin","_checkedplayer","_checkedplayerUID"];
 _flagChecksum = _this select 0;
 
 waitUntil {!isNil "bis_functions_mainscope"};
@@ -29,10 +29,20 @@ while { true } do
 	{
 		{
 			_unit = _x;
-
+			
 			if (owner _unit > _serverID) then
 			{
-				if (alive _unit && !isPlayer _unit && {getText (configFile >> "CfgVehicles" >> typeOf _unit >> "simulation") != "UAVPilot"}) then
+			
+			//disable unit creation checks for zeusAdmins
+			_checkedplayer = [owner _unit] call findClientPlayer;
+			_checkedplayerUID = getPlayerUID _checkedplayer;	
+			_belongstoZeusAdmin =  _checkedplayerUID in call zeusAdmins;
+			
+			//error handling if zeusAdmins isn't defined for whatever reason
+			 if (isNil "_belongstoZeusAdmin") then {_belongstoZeusAdmin = false;};
+					
+			//set cheatflag 
+				if (alive _unit && !_belongstoZeusAdmin && !isPlayer _unit && {getText (configFile >> "CfgVehicles" >> typeOf _unit >> "simulation") != "UAVPilot"}) then
 				{
 					if (isNil "_cheatFlag") then
 					{


### PR DESCRIPTION
to contribute back to the community i prepared everything you need to dynamically create zeus curators in this pull request. this feature is especially nice if you want to do special events on your server.

the feature is only active if there is a zeusAdmin UID defined in A3Wasteland_settings\zeus.sqf.
sample zeus.sqf:
https://gist.github.com/wiking-at/3d16a68223d3128775d9

if an authorized zeusAdmin opens the zeus userinterface the server refreshes all curatorobjects for this user. so there should only be any performance impact if this feature is used.

took me countless iterations and a month of work to get it in this final form - so i hope people like it.
